### PR TITLE
Fix favicons of favourited domains in side menu

### DIFF
--- a/lib/view/drawer.dart
+++ b/lib/view/drawer.dart
@@ -112,7 +112,7 @@ class _DrawerGState extends State<DrawerG> {
                             leading: CircleAvatar(
                               backgroundColor: white,
                               foregroundImage: NetworkImage(
-                                  'https://${widget.user}.bimbala.com/favicon.ico'),
+                                  'https://${snapshot.data[index]}.bimbala.com/favicon.ico'),
                             ),
                             title: Text(
                               snapshot.data[index].toString(),


### PR DESCRIPTION
## Description

The favicons for the domains in the sidebar were not being retrieved properly and were not displaying. I fixed the URL part that was broken and now they are visible.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves an existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
